### PR TITLE
avoid explosion on lein check with Clojure 1.6

### DIFF
--- a/src/image_resizer/resize.clj
+++ b/src/image_resizer/resize.clj
@@ -4,28 +4,31 @@
    [image-resizer.modes         :refer :all]
    [image-resizer.util          :refer :all])
   (:import
+   [java.awt.image BufferedImageOp]
    [org.imgscalr Scalr]))
+
+(def no-ops (into-array BufferedImageOp []))
 
 (defn resize-height-fn
   ([height] (resize-height-fn height automatic))
   ([height scale-method]
      (fn [file]
-       (Scalr/resize (buffered-image file) scale-method fit-height-mode height nil))))
+       (Scalr/resize (buffered-image file) scale-method fit-height-mode height no-ops))))
 
 (defn resize-width-fn
   ([width] (resize-width-fn width automatic))
   ([width scale-method]
      (fn [file]
-       (Scalr/resize (buffered-image file) scale-method fit-width-mode width nil))))
+       (Scalr/resize (buffered-image file) scale-method fit-width-mode width no-ops))))
 
 (defn force-resize-fn
   ([width height] (force-resize-fn width height automatic))
   ([width height scale-method]
      (fn [file]
-       (Scalr/resize (buffered-image file) scale-method fit-exact-mode width height nil))))
+       (Scalr/resize (buffered-image file) scale-method fit-exact-mode width height no-ops))))
 
 (defn resize-fn
   ([width height] (resize-fn width height automatic))
   ([width height scale-method]
      (fn [file]
-       (Scalr/resize (buffered-image file) scale-method width height nil))))
+       (Scalr/resize (buffered-image file) scale-method width height no-ops))))


### PR DESCRIPTION
I think there's a Clojure regression here, and I'm going to poke them to fix it, but in the meantime, this makes it possible to run lein check on projects that depend on image-resizer and clojure 1.6