### PR TITLE
Correcting rotation degrees

### DIFF
--- a/src/image_resizer/rotate.clj
+++ b/src/image_resizer/rotate.clj
@@ -6,13 +6,13 @@
    [org.imgscalr Scalr$Rotation]))
 
 (def counter-clockwise-90
-  Scalr$Rotation/CW_90)
+  Scalr$Rotation/CW_270)
 
 (def counter-clockwise-180
   Scalr$Rotation/CW_180)
 
 (def counter-clockwise-270
-  Scalr$Rotation/CW_270)
+  Scalr$Rotation/CW_90)
 
 (def flip-horizontal
   Scalr$Rotation/FLIP_HORZ)


### PR DESCRIPTION
According to Scalr, CW strand for clockwise. This fixes #8

It might be worth to actually get rid of all 'counter-clockwise' and replace with 'clockwise', but that would introduce some breaking changes....