### PR TITLE
Add some type-hints to avoid reflection and improve performance.

### DIFF
--- a/src/image_resizer/format.clj
+++ b/src/image_resizer/format.clj
@@ -4,7 +4,8 @@
    [image-resizer.core :refer :all])
   (:import
    [java.io File ByteArrayOutputStream ByteArrayInputStream]
-   [javax.imageio ImageIO]))
+   [java.awt.image BufferedImage]
+   [javax.imageio ImageIO ImageWriter]))
 
 (defn as-file [buffered-file file-with-path]
   (let [new-dimensions (dimensions buffered-file)
@@ -16,14 +17,14 @@
   "image-format something like jpg, png.."
   [buffered-image image-format]
   (let [baos (ByteArrayOutputStream.)]
-    (ImageIO/write buffered-image image-format baos)
+    (ImageIO/write ^BufferedImage buffered-image image-format baos)
     (ByteArrayInputStream. (.toByteArray baos))))
 
 (defn as-stream-by-mime-type
   "mime-type something like image/jpeg, image/png.."
-  [buffered-image mime-type]
+  [buffered-image ^String mime-type]
   (let [baos (ByteArrayOutputStream.)]
     (let [writer (.next (ImageIO/getImageWritersByMIMEType mime-type))]
-        (.setOutput writer (ImageIO/createImageOutputStream baos))
-        (.write writer buffered-image)
+        (.setOutput ^ImageWriter writer (ImageIO/createImageOutputStream baos))
+        (.write ^ImageWriter writer ^BufferedImage buffered-image)
         (ByteArrayInputStream. (.toByteArray baos)))))

--- a/src/image_resizer/resize.clj
+++ b/src/image_resizer/resize.clj
@@ -4,7 +4,7 @@
    [image-resizer.modes         :refer :all]
    [image-resizer.util          :refer :all])
   (:import
-   [java.awt.image BufferedImageOp]
+   [java.awt.image BufferedImageOp BufferedImage]
    [org.imgscalr Scalr]))
 
 (def no-ops (into-array BufferedImageOp []))
@@ -13,22 +13,22 @@
   ([height] (resize-height-fn height automatic))
   ([height scale-method]
      (fn [file]
-       (Scalr/resize (buffered-image file) scale-method fit-height-mode height no-ops))))
+       (Scalr/resize ^BufferedImage (buffered-image file) scale-method fit-height-mode height no-ops))))
 
 (defn resize-width-fn
   ([width] (resize-width-fn width automatic))
   ([width scale-method]
      (fn [file]
-       (Scalr/resize (buffered-image file) scale-method fit-width-mode width no-ops))))
+       (Scalr/resize ^BufferedImage (buffered-image file) scale-method fit-width-mode width no-ops))))
 
 (defn force-resize-fn
   ([width height] (force-resize-fn width height automatic))
   ([width height scale-method]
      (fn [file]
-       (Scalr/resize (buffered-image file) scale-method fit-exact-mode width height no-ops))))
+       (Scalr/resize ^BufferedImage (buffered-image file) scale-method fit-exact-mode width height no-ops))))
 
 (defn resize-fn
   ([width height] (resize-fn width height automatic))
   ([width height scale-method]
      (fn [file]
-       (Scalr/resize (buffered-image file) scale-method width height no-ops))))
+       (Scalr/resize ^BufferedImage (buffered-image file) scale-method width height no-ops))))

--- a/src/image_resizer/util.clj
+++ b/src/image_resizer/util.clj
@@ -1,13 +1,13 @@
 (ns image-resizer.util
 (:import
-   [java.io File]
+   [java.io File Serializable]
    [javax.imageio ImageIO]
    [java.awt.image BufferedImage]))
 
 (defn buffered-image [image]
   (if (instance? BufferedImage image)
     image
-    (ImageIO/read ^java.io.ByteArrayInputStream image)))
+    (ImageIO/read ^java.io.Serializable image)))
 
 (defn dimensions [image]
   [(.getWidth image) (.getHeight image)])

--- a/src/image_resizer/util.clj
+++ b/src/image_resizer/util.clj
@@ -7,7 +7,7 @@
 (defn buffered-image [image]
   (if (instance? BufferedImage image)
     image
-    (ImageIO/read image)))
+    (ImageIO/read ^java.io.ByteArrayInputStream image)))
 
 (defn dimensions [image]
   [(.getWidth image) (.getHeight image)])


### PR DESCRIPTION
On some test runs reflection was eating almost 50% of each method computation cost.

We're using the library for rendering image overprints in real-time and seeing some performance issues related to reflection.

Let me know if you're ok with these typehints.