### PR TITLE
Make the dependency a little cleaner

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Image Resizer under the hood wraps [imgscalr](https://github.com/thebuzzmedia/im
 
 Add the following dependency to your project.clj file:
 
-https://clojars.org/image-resizer
+[![Clojars Project](http://clojars.org/image-resizer/latest-version.svg)](http://clojars.org/image-resizer)
 
 ##Usage
 


### PR DESCRIPTION
Rather than the clojars address, why not put the actual clojars banner, or at least the dependency code?