### PR TITLE
Add :verbatim option to as-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,16 @@ If creating your own pipelines seems a bit funky, you can use some nice helpers 
 ```Clojure
 (require [image-resizer.format :as format])
 
-;Saving as a file
-(format/as-file (resize (file "tea-party/mad-hatter.jpg") 10 10)
-                        "/tmp/tea-party/mad-hatter.jpg") ; => "/tmp/tea-party/mad-hatter_10x5.jpg"
+;Saving as an auto-named file
+(format/as-file
+  (resize (file "tea-party/mad-hatter.jpg") 10 10)
+  "/tmp/tea-party/mad-hatter.jpg") ; => "/tmp/tea-party/mad-hatter_10x5.jpg"
+
+;Saving under a specific name
+(format/as-file
+  (resize (file "tea-party/mad-hatter.jpg") 10 10)
+  "/tmp/tea-party/tiny-hatter.jpg"
+  :verbatim) ; => "/tmp/tea-party/tiny-hatter.jpg"
 
 ;To a stream (Useful for s3)
 (format/as-stream (resize (file "tea-party/mad-hatter.jpg") 10 10) "jpg") ; => #<ByteArrayInputStream>

--- a/src/image_resizer/format.clj
+++ b/src/image_resizer/format.clj
@@ -7,10 +7,15 @@
    [java.awt.image BufferedImage]
    [javax.imageio ImageIO ImageWriter]))
 
-(defn as-file [^BufferedImage buffered-file file-with-path]
-  (let [new-dimensions (dimensions buffered-file)
-        resized-file (File. (fs/new-filename file-with-path new-dimensions))]
-    (ImageIO/write buffered-file (fs/extension file-with-path) resized-file)
+(defn as-file [^BufferedImage buffered-file file-with-path & rest]
+  (let [flags (into #{} rest)
+        new-dimensions (dimensions buffered-file)
+        file-name (if (contains? flags :verbatim)
+                    file-with-path
+                    (fs/new-filename file-with-path new-dimensions))
+        file-ext (fs/extension file-name)
+        resized-file (File. file-name)]
+    (ImageIO/write buffered-file file-ext resized-file)
     (.getAbsolutePath resized-file)))
 
 (defn as-stream

--- a/src/image_resizer/fs.clj
+++ b/src/image_resizer/fs.clj
@@ -3,13 +3,16 @@
    [clojure.string :as str]))
 
 (defn- filename [name]
-  (second (re-find #"(.+?)(\.[^.]*$|$)" (last (str/split name #"/")))))
+  (second (re-find #"([^/]+)(?=\.\w+$)" name)))
 
 (defn- path [name]
-  (str/join "/" (butlast (seq (str/split name #"/")))))
+  (second (re-find #"(.*)/" name)))
 
 (defn ^String extension [name]
-  (last (seq (str/split name #"\."))))
+  (re-find #"\w+$" name))
 
 (defn ^String new-filename [file-with-path dimensions]
-  (str (path file-with-path) "/" (filename file-with-path) "_" (str/join "x" dimensions) "." (extension file-with-path)))
+  (format "%s/%s_%s.%s" (path file-with-path)
+                        (filename file-with-path)
+                        (str/join "x" dimensions)
+                        (extension file-with-path)))

--- a/test/image_resizer/unit/t_format.clj
+++ b/test/image_resizer/unit/t_format.clj
@@ -19,10 +19,14 @@
     (instance? class thing)))
 
 (facts "as-file"
-  (fact "writes a buffered image to a file"
+  (fact "writes a buffered image to an auto-renamed file"
     (let [path (.getAbsolutePath test-image)
           new-file (as-file buffered-file path)]
-      (.exists (io/as-file new-file)) => truthy)))
+      (.exists (io/as-file new-file)) => truthy))
+  (fact "writes a buffered image to a user-named file"
+    (let [path "test/fixtures/odd-animal.jpg"
+          new-file (as-file buffered-file path :verbatim)]
+      (.exists (io/as-file path)) => truthy)))
 
 (facts "as-stream"
   (fact "writes a buffered image to an input stream select by format"


### PR DESCRIPTION
I was trying to explicitly name some resized files, and while the auto-naming is great, there wasn't a way get something simpler &mdash; perhaps I'm being oblivious though.  The existing `as-file` call works as it did; this adds an optional parameter.

    (image-resizer.format/as-file 
      some-buffered-image
      "/tmp/resized-and-named-specifically.jpg" 
      :verbatim) ; => "/tmp/resized-and-named-specifically.jpg"

The old tests pass, plus one extra.  Let me know if there's anything else that would help!