### PR TITLE
Increase robustness of bounds checks for crop

### DIFF
--- a/src/image_resizer/crop.clj
+++ b/src/image_resizer/crop.clj
@@ -4,12 +4,17 @@
   (:import
    [org.imgscalr Scalr]))
 
+(defn- bound-dim [original-dim coord dim]
+  (if (> (+ coord dim) original-dim)
+    (- original-dim coord)
+    dim))
+
 (defn crop-fn [x y width height]
   (fn [image]
     (let [buffered (buffered-image image)
           [original-width original-height] (dimensions buffered)
-          crop-width (min original-width width)
-          crop-height (min original-height height)]
+          crop-width (bound-dim original-width x width)
+          crop-height (bound-dim original-height y height)]
       (Scalr/crop buffered x y crop-width crop-height nil))))
 
 (defn crop-width-fn [width]

--- a/test/image_resizer/unit/t_crop.clj
+++ b/test/image_resizer/unit/t_crop.clj
@@ -11,8 +11,14 @@
   (fact "does not crop the width when the given width is bigger than images width"
     ((crop-fn 0 0 12345 200) test-image) => (dimensions-of [600 200]))
 
+  (fact "uses the original width minus x when the given width plus x is bigger than original width"
+    ((crop-fn 20 0 590 200) test-image) => (dimensions-of [580 200]))
+
   (fact "does not crop the height when the given height is bigger than images height"
-    ((crop-fn 0 0 100 12345) test-image) => (dimensions-of [100 314])))
+    ((crop-fn 0 0 100 12345) test-image) => (dimensions-of [100 314]))
+
+  (fact "uses original height minus y when the given height plus y is bigger than original height"
+    ((crop-fn 0 150 100 200) test-image) => (dimensions-of [100 164])))
 
 (facts "about cropping to width and height from a starting coordinate"
   (fact "crops the image to the given width and height starting at a coord"


### PR DESCRIPTION
It was still possible to cause exceptions in Imgscalr by requesting a
crop area that exceeds the image size.  This fix takes in to account the
x and y when determining if the crop request will overflow the image
boundries by capping the width and height.
